### PR TITLE
Upgrade superset to 4.1.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ Pillow
 boto3
 minicli
 sentry-sdk
-marshmallow==3.22.0
+marshmallow<4

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ Pillow
 boto3
 minicli
 sentry-sdk
+# https://github.com/apache/superset/issues/33162
 marshmallow<4

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ Pillow
 boto3
 minicli
 sentry-sdk
+marshmallow==3.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,8 @@
-apache-superset==4.0.2
+apache-superset==4.1.2
+# https://github.com/apache/superset/issues/33162
+# when upgrading superset above, check that this is still needed
+# -> https://github.com/apache/superset/blob/master/requirements/base.txt
+marshmallow<4
 psycopg2-binary
 gunicorn
 gevent
@@ -6,5 +10,3 @@ Pillow
 boto3
 minicli
 sentry-sdk
-# https://github.com/apache/superset/issues/33162
-marshmallow<4


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/608

Test env is available here http://dashboard-tmp.sandbox.data.developpement-durable.gouv.fr/ (iso prod).

"Liste des jeux de données" is broken on both "Patrimoine" dashboard. Something not supported anymore?

<img width="616" alt="Capture d’écran 2025-06-16 à 11 28 25" src="https://github.com/user-attachments/assets/513b9dad-5e45-434a-b1e1-168428d98b6d" />

See upgrade steps here: https://www.notion.so/mtec-ecolab-v1/Upgrade-Superset-2140dc2226f58041b1c3f9ac4cd085b0